### PR TITLE
string conversion fixes with CEGUI_STRING_CLASS_UTF_8

### DIFF
--- a/src/cegui/CEGUIProjectManager.cpp
+++ b/src/cegui/CEGUIProjectManager.cpp
@@ -19,9 +19,9 @@
 QString CEGUIProjectManager::ceguiStringToQString(const CEGUI::String& str)
 {
 #if (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_8)
-	return QString(str.c_str());
+    return QString(str.c_str());
 #elif (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_32)
-	return QString(CEGUI::String::convertUtf32ToUtf8(str.c_str()).c_str());
+    return QString(CEGUI::String::convertUtf32ToUtf8(str.c_str()).c_str());
 #endif
 }
 

--- a/src/cegui/CEGUIProjectManager.cpp
+++ b/src/cegui/CEGUIProjectManager.cpp
@@ -18,7 +18,11 @@
 
 QString CEGUIProjectManager::ceguiStringToQString(const CEGUI::String& str)
 {
-    return QString(CEGUI::String::convertUtf32ToUtf8(str.c_str()).c_str());
+#if (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_8)
+	return QString(str.c_str());
+#elif (CEGUI_STRING_CLASS == CEGUI_STRING_CLASS_UTF_32)
+	return QString(CEGUI::String::convertUtf32ToUtf8(str.c_str()).c_str());
+#endif
 }
 
 CEGUI::String CEGUIProjectManager::qStringToCeguiString(const QString& str)
@@ -558,8 +562,7 @@ QStringList CEGUIProjectManager::getAvailableFonts() const
     auto& fontRegistry = CEGUI::FontManager::getSingleton().getRegisteredFonts();
     for (const auto& pair : fontRegistry)
     {
-        auto id = CEGUI::String::convertUtf32ToUtf8(pair.first.c_str());
-        fonts.append(id.c_str());
+        fonts.append(ceguiStringToQString(pair.first));
     }
 
     std::sort(fonts.begin(), fonts.end());
@@ -575,8 +578,7 @@ QStringList CEGUIProjectManager::getAvailableImages() const
     auto it = CEGUI::ImageManager::getSingleton().getIterator();
     while (!it.isAtEnd())
     {
-        auto id = CEGUI::String::convertUtf32ToUtf8(it.getCurrentKey().c_str());
-        images.append(id.c_str());
+        images.append(ceguiStringToQString(it.getCurrentKey()));
         ++it;
     }
 
@@ -602,7 +604,7 @@ void CEGUIProjectManager::getAvailableWidgetsBySkin(std::map<QString, QStringLis
     auto it = CEGUI::WindowFactoryManager::getSingleton().getFalagardMappingIterator();
     while (!it.isAtEnd())
     {
-        const QString windowType = CEGUI::String::convertUtf32ToUtf8(it.getCurrentValue().d_windowType.c_str()).c_str();
+        const QString windowType = ceguiStringToQString(it.getCurrentValue().d_windowType);
 
         auto sepPos = windowType.indexOf('/');
         assert(sepPos >= 0);

--- a/src/editors/layout/LayoutEditor.cpp
+++ b/src/editors/layout/LayoutEditor.cpp
@@ -148,8 +148,7 @@ void LayoutEditor::getRawData(QByteArray& outRawData)
     }
 
     CEGUI::String layoutString = CEGUI::WindowManager::getSingleton().getLayoutAsString(*currentRootWidget);
-    const std::string utf8 = CEGUI::String::convertUtf32ToUtf8(layoutString.c_str());
-    outRawData = utf8.c_str();
+    outRawData = CEGUIProjectManager::ceguiStringToQString(layoutString).toUtf8();
 }
 
 void LayoutEditor::createSettings(Settings& mgr)


### PR DESCRIPTION
Hi niello :D

Finally got it to build and looks pretty cool!
Took me a while to find a way to generate the visual studio project files (qmake -tp vc) and QT 5.12 seems to only support x64 with MSVC 2015.

The MSVC 2015 fixes should be my next pull request.

This is only needed if the CEGUI string class is changed to UTF_8

