### PR TITLE
MSVC 2015 build fixes

### DIFF
--- a/src/cegui/CEGUIProjectManager.h
+++ b/src/cegui/CEGUIProjectManager.h
@@ -2,6 +2,7 @@
 #define CEGUIPROJECTMANAGER_H
 #include "qstring.h"
 #include "qimage.h"
+#include <memory>
 
 // A singleton CEGUI manager class controls the loaded project and encapsulates a running CEGUI instance.
 // Right now CEGUI can only be instantiated once because it's full of singletons. This might change in the

--- a/src/editors/BitmapEditor.cpp
+++ b/src/editors/BitmapEditor.cpp
@@ -1,4 +1,5 @@
 #include "src/editors/BitmapEditor.h"
+#include <memory>
 
 BitmapEditor::BitmapEditor(const QString& filePath)
     : EditorBase(/*nullptr,*/ filePath)

--- a/src/editors/EditorBase.h
+++ b/src/editors/EditorBase.h
@@ -3,6 +3,7 @@
 
 #include "qstring.h"
 #include "qvariant.h"
+#include <memory>
 
 // This is the base class for a class that takes a file and allows manipulation with it
 

--- a/src/ui/CEGUIGraphicsScene.cpp
+++ b/src/ui/CEGUIGraphicsScene.cpp
@@ -9,6 +9,7 @@
 #include "qopenglcontext.h"
 #include "qopenglfunctions.h"
 #include "qopenglfunctions_2_0.h"
+#include <ctime>
 
 CEGUIGraphicsScene::CEGUIGraphicsScene()
     : timeOfLastRender(time(nullptr))

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <memory>
 
 // The central window of the application
 

--- a/src/ui/SettingEntryEditors.cpp
+++ b/src/ui/SettingEntryEditors.cpp
@@ -301,7 +301,7 @@ SettingEntryEditorCombobox::SettingEntryEditorCombobox(SettingsEntry& entry)
 
     updateValueInUI();
 
-    connect(entryWidget, qOverload<int>(&QComboBox::currentIndexChanged), this, &SettingEntryEditorCombobox::onChange);
+    connect(entryWidget, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingEntryEditorCombobox::onChange);
 }
 
 void SettingEntryEditorCombobox::updateValueInUI()

--- a/src/util/Settings.h
+++ b/src/util/Settings.h
@@ -3,6 +3,7 @@
 
 #include "qvariant.h"
 #include "vector"
+#include <memory>
 
 // Application global settings system
 

--- a/src/util/SettingsCategory.h
+++ b/src/util/SettingsCategory.h
@@ -3,6 +3,7 @@
 
 #include "qstring.h"
 #include "vector"
+#include <memory>
 
 // Groups sections, is usually represented by a tab in the interface
 

--- a/src/util/SettingsEntry.h
+++ b/src/util/SettingsEntry.h
@@ -2,6 +2,7 @@
 #define SETTINGSENTRY_H
 
 #include "qvariant.h"
+#include <memory>
 
 // Is the value itself, inside a section. This is what's directly used when
 // accessing settings.

--- a/src/util/SettingsSection.h
+++ b/src/util/SettingsSection.h
@@ -3,6 +3,7 @@
 
 #include "qstring.h"
 #include "vector"
+#include <memory>
 
 // Groups entries, is usually represented by a group box in the interface
 


### PR DESCRIPTION
<memory> for std::unique_ptr

The qOverload fix is from here: https://forum.qt.io/topic/93385/how-to-use-qoverload/7

