### PR TITLE
Fix an OpenGL3Renderer FBO crash and request the CompatibilityProfile

### DIFF
--- a/src/cegui/CEGUIProjectManager.cpp
+++ b/src/cegui/CEGUIProjectManager.cpp
@@ -120,6 +120,7 @@ void CEGUIProjectManager::ensureCEGUIInitialized()
 
     QSurfaceFormat format;
     format.setSamples(0);
+    format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
     glContext = new QOpenGLContext(); // TODO: destroy
     glContext->setFormat(format);

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -699,6 +699,13 @@ void MainWindow::openEditorTab(const QString& absolutePath)
 {
     if (activateEditorTabByFilePath(absolutePath)) return;
 
+    if(Q_UNLIKELY(!CEGUIProjectManager::Instance().makeOpenGLContextCurrent())) // needed if a Window has "AutoRenderingSurface" set, as that will call Window::allocateRenderingWindow()
+    {
+        //qWarning("QOpenGLWidget: Failed to make context current");
+        assert(false);
+        return;
+    }
+
     EditorBase* editor = createEditorForFile(absolutePath);
     if (!editor) return;
 


### PR DESCRIPTION
This might also have crashed with the legacy OpenGLRenderer.

Also explicitly request the CompatibilityProfile.