### PR TITLE
Fix addChildAtIndex to addChildAtIndex

### DIFF
--- a/src/cegui/CEGUIUtils.cpp
+++ b/src/cegui/CEGUIUtils.cpp
@@ -186,7 +186,7 @@ bool insertChild(CEGUI::Window* parent, CEGUI::Window* widget, size_t index)
     }
 
     if (index < parent->getChildCount())
-        parent->addChildToIndex(widget, index);
+        parent->addChildAtIndex(widget, index);
     else
         parent->addChild(widget);
 


### PR DESCRIPTION
CEGUI::Element::addChildAtIndex renamed to CEGUI::Element::addChildAtIndex at https://github.com/cegui/cegui/blob/master/cegui/include/CEGUI/Element.h#L831